### PR TITLE
Allow the mlflow run name to be custom

### DIFF
--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -18,6 +18,12 @@ from mlflow.exceptions import MlflowException
 
 CONFIG_SCHEMA = {
     "experiment_name": Field(StringSource, is_required=True, description="MlFlow experiment name."),
+    "run_name": Field(
+        Noneable(StringSource),
+        default_value=None,
+        is_required=False,
+        description="MLFlow run name."
+    ),
     "mlflow_tracking_uri": Field(
         Noneable(StringSource),
         default_value=None,
@@ -73,11 +79,12 @@ class MlFlow(metaclass=MlflowMeta):
     def __init__(self, context):
         # Context associated attributes
         self.log = context.log
-        self.run_name = context.dagster_run.job_name
         self.dagster_run_id = context.run_id
+        job_name = context.dagster_run.job_name
 
         # resource config attributes
         resource_config = context.resource_config
+        self.run_name = resource_config.get("run_name", job_name)
         self.tracking_uri = resource_config.get("mlflow_tracking_uri")
         if self.tracking_uri:
             mlflow.set_tracking_uri(self.tracking_uri)

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
@@ -77,6 +77,7 @@ def basic_context(mlflow_run_config, dagster_run):
 def child_context(basic_context, mlflow_run_config):
     resource_config = deepcopy(mlflow_run_config["resources"]["mlflow"]["config"])
     resource_config["parent_run_id"] = basic_context.run_id
+    resource_config["run_name"] = "child"  # Custom run name
     return MagicMock(
         resource_config=resource_config,
         log=basic_context.log,
@@ -117,7 +118,7 @@ def test_mlflow_constructor_basic(
 
     # - the context associated attributes passed have been set
     assert mlf.log == context.log
-    assert mlf.run_name == context.dagster_run.job_name
+    assert mlf.run_name == context.resource_config.get("run_name", context.dagster_run.job_name)
     assert mlf.dagster_run_id == context.run_id
 
     # - the tracking URI is the same as what was passed


### PR DESCRIPTION
## Summary & Motivation

The MLFlow run name is by default the dagster job name. But this is not very flexible if I run a job with different configs: I cannot change the job name from the Launchpad.

This PR allows to set a custom run_name. If no run_name is provided, its default is the dagster job name.

## How I Tested These Changes

I've added a custom run_name in the `child_context` in `dagster_mlflow_tests`, and tested that the custom run_name is being used.